### PR TITLE
test: suppress make flags from environment

### DIFF
--- a/integrate/test_integrate.py
+++ b/integrate/test_integrate.py
@@ -1,5 +1,4 @@
 import math
-import os
 import subprocess
 import tempfile
 import time
@@ -93,22 +92,6 @@ def test_xdist_double(jobserver_path_1, jobserver_path_4):
 
 
 # Makefile tests - jobserver spawned automatically by make. Plain pytest only.
-
-
-def test_make_xdist_fails():
-    """Check we error if we try to load jobserver from env, but xdist is active"""
-    makeflags_env = os.environ.copy()
-    makeflags_env["MAKEFLAGS"] = "w -j --jobserver-fds=7,8"
-    complete_process = subprocess.run(
-        ["pytest", "-n2", "4"], env=makeflags_env, stderr=subprocess.PIPE
-    )
-    assert (
-        complete_process.returncode == 4
-    ), "Expected pytest would fail to run with MAKEFLAGS and xdist"
-    assert (
-        b"ERROR: pytest-jobserver does not support using pytest-xdist with MAKEFLAGS"
-        in complete_process.stderr
-    ), "Expected pytest would warn about failure with MAKEFLAGS and xdist"
 
 
 def test_make():

--- a/pytest_jobserver/configure.py
+++ b/pytest_jobserver/configure.py
@@ -7,11 +7,19 @@ import pytest
 from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 
-from .filesystem import FileDescriptor, FileDescriptorsRW, is_fifo, is_rw_ok
+from .filesystem import (
+    FileDescriptor,
+    FileDescriptorsRW,
+    first_environ_get,
+    is_fifo,
+    is_rw_ok,
+)
 from .metadata import VERSION
 from .plugin import JobserverPlugin
 
 __version__ = VERSION
+
+MAKEFLAGS_ENVIRONMENT_VARIABLES = ("CARGO_MAKEFLAGS", "MAKEFLAGS", "MFLAGS")
 
 
 def pytest_addoption(parser: Parser) -> None:
@@ -45,12 +53,7 @@ def jobserver_from_options(config: Config) -> Optional[FileDescriptorsRW]:
 
 
 def jobserver_from_env(config: Config) -> Optional[FileDescriptorsRW]:
-    makeflags = (
-        os.environ.get("CARGO_MAKEFLAGS")
-        or os.environ.get("MAKEFLAGS")
-        or os.environ.get("MFLAGS")
-    )
-
+    makeflags = first_environ_get(MAKEFLAGS_ENVIRONMENT_VARIABLES)
     if makeflags is None:
         return None
 

--- a/pytest_jobserver/filesystem.py
+++ b/pytest_jobserver/filesystem.py
@@ -1,6 +1,6 @@
 import os
 import stat
-from typing import NewType, Tuple
+from typing import Iterable, NewType, Optional, Tuple
 
 FileDescriptor = NewType("FileDescriptor", int)
 # A 2-tuple of file descriptors, representing a read/write pair
@@ -13,3 +13,11 @@ def is_fifo(path: str) -> bool:
 
 def is_rw_ok(path: str) -> bool:
     return os.access(path, os.R_OK | os.W_OK)
+
+
+def first_environ_get(keys: Iterable[str]) -> Optional[str]:
+    for key in keys:
+        value = os.environ.get(key)
+        if value is not None:
+            return value
+    return None

--- a/pytest_jobserver/test/test_filesystem.py
+++ b/pytest_jobserver/test/test_filesystem.py
@@ -1,0 +1,22 @@
+from typing import Any
+
+from pytest_jobserver.filesystem import is_fifo, is_rw_ok
+
+from .jobserver import make_jobserver
+
+TestDir = Any
+
+
+def test_is_fifo(testdir: TestDir) -> None:
+    fifo_path = make_jobserver(testdir.tmpdir, "jobserver_fifo", 0)
+    assert is_fifo(fifo_path) is True
+
+    not_fifo_path = testdir.makefile(".txt", jobserver="X")
+    assert is_fifo(not_fifo_path) is False
+
+
+def test_is_rw_ok(testdir: TestDir) -> None:
+    fifo_path = make_jobserver(testdir.tmpdir, "jobserver_fifo", 0)
+    assert is_rw_ok(fifo_path) is True
+
+    assert is_rw_ok("/") is False


### PR DESCRIPTION
As we are using make internally in our testing pipeline, test the edge case where we have no make flags at all by removing them from the test environment.