### PR TITLE
Remove the FIFO requirement

### DIFF
--- a/pytest_jobserver/configure.py
+++ b/pytest_jobserver/configure.py
@@ -10,7 +10,6 @@ from .system import (
     FileDescriptor,
     FileDescriptorsRW,
     environ_get_first,
-    is_fifo,
     is_rw_ok,
 )
 
@@ -20,9 +19,6 @@ MAKEFLAGS_ENVIRONMENT_VARIABLES = ("CARGO_MAKEFLAGS", "MAKEFLAGS", "MFLAGS")
 def path_to_file_descriptors(jobserver_path: str) -> Optional[FileDescriptorsRW]:
     if os.path.exists(jobserver_path) is False:
         raise pytest.UsageError("jobserver doesn't exist: {}".format(jobserver_path))
-
-    if is_fifo(jobserver_path) is False:
-        raise pytest.UsageError("jobserver is not a fifo: {}".format(jobserver_path))
 
     if is_rw_ok(jobserver_path) is False:
         raise pytest.UsageError(

--- a/pytest_jobserver/system.py
+++ b/pytest_jobserver/system.py
@@ -1,5 +1,4 @@
 import os
-import stat
 from typing import Iterable, NewType, Optional, Tuple
 
 FileDescriptor = NewType("FileDescriptor", int)
@@ -13,10 +12,6 @@ def environ_get_first(keys: Iterable[str]) -> Optional[str]:
         if value is not None:
             return value
     return None
-
-
-def is_fifo(path: str) -> bool:
-    return stat.S_ISFIFO(os.stat(path).st_mode)
 
 
 def is_rw_ok(path: str) -> bool:

--- a/pytest_jobserver/test/test_plugin.py
+++ b/pytest_jobserver/test/test_plugin.py
@@ -169,16 +169,3 @@ def test_server_not_found(testdir: TestDir) -> None:
 
     result.stderr.fnmatch_lines(["ERROR: jobserver doesn't exist: non_existent_file"])
     assert result.ret == 4
-
-
-def test_server_not_fifo(testdir: TestDir) -> None:
-    testdir.makefile(".txt", jobserver="X")
-    testdir.makepyfile("""
-        def test_pass(request):
-            pass
-    """)
-    # Run our test
-    result = testdir.runpytest("-v", "--jobserver", "jobserver.txt")
-
-    result.stderr.fnmatch_lines(["ERROR: jobserver is not a fifo: jobserver.txt"])
-    assert result.ret == 4

--- a/pytest_jobserver/test/test_system.py
+++ b/pytest_jobserver/test/test_system.py
@@ -2,7 +2,7 @@ from typing import Any, Optional
 
 import pytest
 
-from pytest_jobserver.system import environ_get_first, is_fifo, is_rw_ok
+from pytest_jobserver.system import environ_get_first, is_rw_ok
 
 from .jobserver import make_jobserver
 
@@ -23,14 +23,6 @@ def test_environ_get_first(
     setenv_if_not_none("A", env_a)
     setenv_if_not_none("B", env_b)
     assert environ_get_first(("A", "B")) == env_expected
-
-
-def test_is_fifo(testdir: TestDir) -> None:
-    fifo_path = make_jobserver(testdir.tmpdir, "jobserver_fifo", 0)
-    assert is_fifo(fifo_path) is True
-
-    not_fifo_path = testdir.makefile(".txt", jobserver="X")
-    assert is_fifo(not_fifo_path) is False
 
 
 def test_is_rw_ok(testdir: TestDir) -> None:


### PR DESCRIPTION
Do not require that the jobserver path corresponds to an actual named pipe.  Token-accounting jobserver implementations such as steve [1] and guildmaster [2] use a character device instead, while the draft version of nixos-jobserver [3] uses a pseudo-file via FUSE.  GNU make does not enforce a named pipe either.

[1] https://gitweb.gentoo.org/proj/steve.git
[2] https://codeberg.org/amonakov/guildmaster
[3] https://github.com/NixOS/nixpkgs/pull/314888