### PR TITLE
Obtain job tokens for test collection too

### DIFF
--- a/pytest_jobserver/plugin.py
+++ b/pytest_jobserver/plugin.py
@@ -34,6 +34,11 @@ class JobserverPlugin(object):
         self._thread_locals = threading.local()
 
     @pytest.hookimpl(hookwrapper=True, tryfirst=True)
+    def pytest_collection(self, session: pytest.Session) -> Iterator[Any]:
+        with _hold_token(self._fds):
+            yield
+
+    @pytest.hookimpl(hookwrapper=True, tryfirst=True)
     def pytest_runtest_protocol(self, item: Item) -> Iterator[Any]:
         with _hold_token(self._fds) as token:
             self._thread_locals.token = token


### PR DESCRIPTION
The test collection phase is also performed by `pytest-xdist` in parallel, and can be quite resource-intensive in larger packages (such as NumPy), so guard it with job tokens as well.