### PR TITLE
Do not acquire a job token for `gw0` worker

### DIFF
--- a/integrate/test_long.py
+++ b/integrate/test_long.py
@@ -5,9 +5,14 @@ def pause():
     sleep(2)
 
 
+# NB: we're running one extra job to offset the implicit slot.
 def test_0(request):
     pause()
 
 
 def test_1(request):
+    pause()
+
+
+def test_2(request):
     pause()

--- a/pytest_jobserver/plugin.py
+++ b/pytest_jobserver/plugin.py
@@ -20,7 +20,14 @@ __version__ = VERSION
 
 
 @contextmanager
-def _hold_token(fds: FileDescriptorsRW) -> Iterator[int]:
+def _hold_token(fds: FileDescriptorsRW) -> Iterator[int | None]:
+    # The parent process has already acquired one token for us, so run
+    # one parallel job without a job token. For convenience, we will
+    # just run jobs from gw0 without tokens.
+    if os.environ.get("PYTEST_XDIST_WORKER", "gw0") == "gw0":
+        yield None
+        return
+
     fd_read, fd_write = fds
     token_byte = os.read(fd_read, 1)
     token_int = ord(token_byte)


### PR DESCRIPTION
Run the tests on `gw0` worker without acquiring a job token, to account for the implicit job slot, i.e. the token acquired by the parent process.  This ensures that for `make -jN`, N tests will be run simultaneously rather than N-1 (since that make invocation provides N-1 job tokens).

Note that this implementation is far from perfect.  Notably, if `gw0` runs out of tests, other workers will still unnecessarily acquire job tokens even though the "implicit slot" is free now.  It also does not handle uses other than pytest-xdist.  A more correct implementation would require some kind of indirection in acquiring tokens that is shared across processes.

Fixes #148